### PR TITLE
chore(gitignore): added venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 **/__pycache__/
 *.log
+*/venv/


### PR DESCRIPTION
## What?
Updated .gitignore to ignore python virtual environments named "venv"

## Why?
These environments are for testing only. They thould remain on local workspaces

## How?
Added */venv to the .gitignore file

## Testing?
Since added, around 900 changes from the venv creation were ignored 

## Screenshots
![image](https://github.com/user-attachments/assets/80bef75e-784e-4758-86e4-6ceec1bffdac)

## Anything Else?
It is important that everyone names "venv" their python virtual environments