### PR TITLE
hotfix(npc-schema): changed validation to not be empty

### DIFF
--- a/api_npc/schemas/schemas.py
+++ b/api_npc/schemas/schemas.py
@@ -15,48 +15,48 @@ class NpcSchema:
     # Validate the named: Make sure the named has at least 5 characters
     @validates('named')
     def validate_named(self, value):
-        if len(value) < 5:
-            raise ValidationError('Name must be at least 5 characters long')
+        if len(value) < 1:
+            raise ValidationError('Name must not be empty')
 
     # Validate the role: Make sure the role has at least 5 characters
     @validates('role')
     def validate_role(self, value):
-        if len(value) < 5:
-            raise ValidationError('Role must be at least 5 characters long')
+        if len(value) < 1:
+            raise ValidationError('Role must not be empty')
     
     @validates('picture')
     def validate_picture(self, value):
         if len(value) < 5:
-            raise ValidationError('Picture must be at least 5 characters long')
+            raise ValidationError('Picture URL is too short')
 
     # Validate the hit die: Make sure it's at least 2 characters long
     @validates('personality')
     def validate_personality(self, value):
-        if len(value) < 2:
-            raise ValidationError('Personality must be at least 2 characters long')
+        if len(value) < 1:
+            raise ValidationError('Personality must not be empty')
 
     # Validate the primary ability: Make sure it’s at least 5 characters long
     @validates('inventory')
     def validate_inventory(self, value):
-        if len(value) < 5:
-            raise ValidationError('Inventory must be at least 5 characters long')
+        if len(value) < 1:
+            raise ValidationError('Inventory must not be empty')
 
     # Validate saving throw proficiencies: Make sure it’s at least 5 characters long
     @validates('likes')
     def validate_likes(self, value):
-        if len(value) < 5:
-            raise ValidationError('Likes must be at least 5 characters long')
+        if len(value) < 1:
+            raise ValidationError('Likes must not be empty')
 
     # Validate armor and weapon proficiencies: Make sure it’s at least 5 characters long
     @validates('money')
     def validate_money(self, value):
-        if len(value) < 5:
-            raise ValidationError('Money must be at least 5 characters long')
+        if len(value) < 1:
+            raise ValidationError('Money must not be empty')
     
     @validates('backstory')
     def validate_backstory(self, value):
-        if len(value) < 5:
-            raise ValidationError('Backstory must be at least 5 characters long')
+        if len(value) < 1:
+            raise ValidationError('Backstory must not be empty')
 
     # You can also add validation for the "extra" field later if needed
     # @validates('extra')


### PR DESCRIPTION
## What?
Changed NPC API validations

## Why?
To be more permissible when typing shorter terms to fill out a field

## How?
I changed the validate decorators

## Testing?
I tried 1 letter as input and everything worked alright